### PR TITLE
[FEAT] Support multi target group

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) for deploying to [Amazon ECS](https://aws.amazon.com/ecs/).
 
 * Requires the aws cli tool be installed
-* Registers a new task definition based on a given JSON file ([`register-task-definition`](http://docs.aws.amazon.com/cli/latest/reference/ecs/register-task-definition.html]))
+* Registers a new task definition based on a given JSON file ([`register-task-definition`](http://docs.aws.amazon.com/cli/latest/reference/ecs/register-task-definition.html))
+* Create the ECS service if not exist ([`create-service`](https://docs.aws.amazon.com/cli/latest/reference/ecs/create-service.html))
 * Updates the ECS service to use the new task definition ([`update-service`](http://docs.aws.amazon.com/cli/latest/reference/ecs/update-service.html))
 * Waits for the service to stabilize ([`wait services-stable`](http://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html))
 
@@ -66,6 +67,25 @@ image:
 
 An IAM ECS Task Role to assign to tasks.
 Requires the `iam:PassRole` permission for the ARN specified.
+
+### `load-balancers-json` (optional)
+
+This is the load balancer config json which to be used to setup multiple
+load-balancer(CLB)/target-group(ALB, NLB) for the services.
+
+Notice this will overrite the following target-group config.
+
+```sh
+[
+  {
+    "targetGroupArn": "string", # for ALB and NLB
+    "loadBalancerName": "string", # for CLB
+    "containerName": "string",
+    "containerPort": integer
+  }
+  ...
+]
+```
 
 ### `target-group` (optional)
 
@@ -161,7 +181,7 @@ This plugin will create the ECS Service if it does not already exist, which addi
 To run the tests:
 
 ```bash
-docker-compose run tests
+docker-compose run --rm tests
 ```
 
 ## License

--- a/hooks/command
+++ b/hooks/command
@@ -56,7 +56,7 @@ if [[ -n $load_balancers_json_loc ]]; then
     exit 1
   fi
 
-  load_balancers_json=$(cat "$load_balancers_json_loc" | jq '.')
+  load_balancers_json=$(cat "$load_balancers_json_loc" | jq --compact-output '.')
 fi
 
 if [[ $region != "" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -46,6 +46,19 @@ task_cpu=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_CPU:-""}
 task_memory=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_MEMORY:-""}
 network_configuration=${BUILDKITE_PLUGIN_ECS_DEPLOY_NETWORK_CONFIGURATION:-""}
 
+load_balancers_json_loc=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCERS_JSON:-""}
+
+if [[ -n $load_balancers_json_loc ]]; then
+  if [[ $(jq '. | length' "$load_balancers_json_loc") == "0" ]]; then
+    echo "^^^"
+    echo "Invalid load balancers configuration"
+    echo 'JSON configuration should have minimal length of 1'
+    exit 1
+  fi
+
+  load_balancers_json=$(cat "$load_balancers_json_loc" | jq '.')
+fi
+
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
   AWS_DEFAULT_REGION=${region}
@@ -74,7 +87,12 @@ function create_service() {
     local service_name=$3
     local desired_count=$4
     local target_group_arguments
-    target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
+
+    if [[ -n $load_balancers_json ]]; then
+      target_group_arguments="${load_balancers_json}"
+    else
+      target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
+    fi
 
     # shellcheck disable=SC2016
     service_defined=$(aws ecs describe-services \

--- a/hooks/command
+++ b/hooks/command
@@ -89,7 +89,7 @@ function create_service() {
     local target_group_arguments
 
     if [[ -n $load_balancers_json ]]; then
-      target_group_arguments=$(echo "--load-balancer '${load_balancers_json}'")
+      target_group_arguments=$(echo "--load-balancers '${load_balancers_json}'")
     else
       target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
     fi

--- a/hooks/command
+++ b/hooks/command
@@ -89,10 +89,12 @@ function create_service() {
     local target_group_arguments
 
     if [[ -n $load_balancers_json ]]; then
-      target_group_arguments="--load-balancers '${load_balancers_json}'"
+      target_group_arguments=$(echo "--load-balancer '${load_balancers_json}'")
     else
       target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
     fi
+
+    echo "--- :ecs: target group arguments: ${target_group_arguments}"
 
     # shellcheck disable=SC2016
     service_defined=$(aws ecs describe-services \

--- a/hooks/command
+++ b/hooks/command
@@ -89,7 +89,7 @@ function create_service() {
     local target_group_arguments
 
     if [[ -n $load_balancers_json ]]; then
-      target_group_arguments="${load_balancers_json}"
+      target_group_arguments="--load-balancers '${load_balancers_json}'"
     else
       target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
     fi

--- a/hooks/command
+++ b/hooks/command
@@ -56,7 +56,7 @@ if [[ -n $load_balancers_json_loc ]]; then
     exit 1
   fi
 
-  load_balancers_json=$(cat "$load_balancers_json_loc" | jq --compact-output '.')
+  load_balancers_json=$(cat "$load_balancers_json_loc" | jq '.')
 fi
 
 if [[ $region != "" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -56,7 +56,7 @@ if [[ -n $load_balancers_json_loc ]]; then
     exit 1
   fi
 
-  load_balancers_json=$(cat "$load_balancers_json_loc" | jq '.')
+  load_balancers_json=$(cat "$load_balancers_json_loc" | jq --compact-output '.')
 fi
 
 if [[ $region != "" ]]; then
@@ -89,7 +89,7 @@ function create_service() {
     local target_group_arguments
 
     if [[ -n $load_balancers_json ]]; then
-      target_group_arguments=$(echo "--load-balancers '${load_balancers_json}'")
+      target_group_arguments=$(echo "--load-balancers ${load_balancers_json}")
     else
       target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
     fi
@@ -228,6 +228,12 @@ if [[ "$lb_config" == "null" ]]; then
     echo "$error. ELB configured but none set in container"
     exit 1
   fi
+fi
+
+# This is a naive check for multi load balancer config
+if [[ -n $load_balancers_json ]]; then
+  target_container=$(echo $load_balancers_json | jq -r '.[0].containerName')
+  target_port=$(echo $load_balancers_json | jq -r '.[0].containerPort')
 fi
 
 if [[ "$lb_config" == "null" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -22,12 +22,14 @@ configuration:
       type: string
     target-group:
       type: string
-    load-balanccer-name:
+    load-balancer-name:
       type: string
     target-container-name:
       type: string
     target-container-port:
       type: integer
+    load-balancers-json:
+      type: string
     execution-role:
       type: string
     deployment-config:


### PR DESCRIPTION
Use load-balancers-json which point to a config file and this allow the service to be deployed to handle multiple taget groups (point to the same service)